### PR TITLE
feat(humidifier): add DR-HHM005S (HM735S) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The following product types are supported. All variants have been tested.
 | Circulation Fans | DR-HAF, DR-HPF | Circulation fans with oscillation control |
 | Ceiling Fans | DR-HCF | Ceiling fans with light control |
 | Air Conditioners | DR-HAC | Portable air conditioners |
-| Humidifiers | DR-HEC | Evaporative coolers |
+| Humidifiers | DR-HHM, DR-HEC | Smart humidifiers and evaporative coolers |
 
 Models that have been specifically tested can be found below.
 
@@ -123,6 +123,7 @@ Features for Air Conditioners include:
 
 #### Humidifiers
 
+- HM735S Smart Humidifier (DR-HHM005S)
 - Evaporative Cooler 712S (DR-HEC002S)
 
 Features for Humidifiers include:
@@ -130,7 +131,9 @@ Features for Humidifiers include:
 - Preset modes (Normal, Auto, Sleep, Natural)
 - Set Speed (1-4)
 - Humidity control (40-90%)
-- Oscillate (true, false)
+- RGB night light (DR-HHM005S)
+- Sleep mode switch (DR-HHM005S)
+- Oscillate (true, false, DR-HEC002S)
 
 
 Product name could be found on the package box, user manual, or the label on the device.

--- a/custom_components/dreo/const.py
+++ b/custom_components/dreo/const.py
@@ -83,6 +83,7 @@ class DreoDirective(StrEnum):
     AMBIENT_RGB_SPEED = "atmspeed"
     HUMIDIFIER_RGB_MODE = "rgbmode"
     HUMIDIFIER_RGB_COLOR = "rgb_color"
+    HUMIDIFIER_LED_LEVEL = "ledlevel"
     LIGHT_BRIGHTNESS = "brightness"
     LIGHT_COLOR_TEMP = "colortemp"
     RGB_HUMIDITY_THRESHOLD = "rgb_threshold"

--- a/custom_components/dreo/const.py
+++ b/custom_components/dreo/const.py
@@ -83,7 +83,6 @@ class DreoDirective(StrEnum):
     AMBIENT_RGB_SPEED = "atmspeed"
     HUMIDIFIER_RGB_MODE = "rgbmode"
     HUMIDIFIER_RGB_COLOR = "rgb_color"
-    HUMIDIFIER_LED_LEVEL = "ledlevel"
     LIGHT_BRIGHTNESS = "brightness"
     LIGHT_COLOR_TEMP = "colortemp"
     RGB_HUMIDITY_THRESHOLD = "rgb_threshold"

--- a/custom_components/dreo/const.py
+++ b/custom_components/dreo/const.py
@@ -81,6 +81,8 @@ class DreoDirective(StrEnum):
     AMBIENT_RGB_COLOR = "atmcolor"
     AMBIENT_RGB_BRIGHTNESS = "atmbri"
     AMBIENT_RGB_SPEED = "atmspeed"
+    HUMIDIFIER_RGB_MODE = "rgbmode"
+    HUMIDIFIER_RGB_COLOR = "rgb_color"
     LIGHT_BRIGHTNESS = "brightness"
     LIGHT_COLOR_TEMP = "colortemp"
     RGB_HUMIDITY_THRESHOLD = "rgb_threshold"
@@ -121,6 +123,12 @@ class DreoDeviceType(StrEnum):
 
 
 CIR_FAN_SWING_ENTITY = "swing_direction"
+
+# Humidifier models whose RGB night light uses the `rgb_color` + `rgbmode` directives
+# (distinct from the `atmcolor`/`ambient_switch` dialect used by circulation fans and HEC).
+# These models typically omit `"light"` from their cloud-side entitySupports list, so we
+# force-create a light entity for them.
+HUMIDIFIER_RGB_COLOR_MODELS = frozenset({"DR-HHM005S"})
 
 
 class DreoErrorCode(StrEnum):

--- a/custom_components/dreo/coordinator.py
+++ b/custom_components/dreo/coordinator.py
@@ -913,10 +913,14 @@ class DreoHumidifierDeviceData(DreoGenericDeviceData):
         # the atm* keys.
         if (hum_rgb_mode := state.get(DreoDirective.HUMIDIFIER_RGB_MODE)) is not None:
             humidifier_data.rgb_mode = str(hum_rgb_mode)
-            humidifier_data.rgb_state = str(hum_rgb_mode) != "Off"
 
         if (hum_rgb_color := state.get(DreoDirective.HUMIDIFIER_RGB_COLOR)) is not None:
             humidifier_data.rgb_color = int(hum_rgb_color)
+
+        # ledlevel ("On"/"Off") is the authoritative on/off switch on HHM005S.
+        # rgbmode ("Custom"/...) describes the animation mode but doesn't accept "Off".
+        if (led_level := state.get(DreoDirective.HUMIDIFIER_LED_LEVEL)) is not None:
+            humidifier_data.rgb_state = str(led_level) == "On"
 
         if (
             rgb_brightness := state.get(DreoDirective.AMBIENT_RGB_BRIGHTNESS)

--- a/custom_components/dreo/coordinator.py
+++ b/custom_components/dreo/coordinator.py
@@ -907,6 +907,17 @@ class DreoHumidifierDeviceData(DreoGenericDeviceData):
         if (rgb_color := state.get(DreoDirective.AMBIENT_RGB_COLOR)) is not None:
             humidifier_data.rgb_color = int(rgb_color)
 
+        # Models like DR-HHM005S report the night-light state under different keys:
+        # rgbmode ("Custom"/"Off"/...) and rgb_color (packed 24-bit int). Parse these
+        # when present; they override the atm* values since this firmware never reports
+        # the atm* keys.
+        if (hum_rgb_mode := state.get(DreoDirective.HUMIDIFIER_RGB_MODE)) is not None:
+            humidifier_data.rgb_mode = str(hum_rgb_mode)
+            humidifier_data.rgb_state = str(hum_rgb_mode) != "Off"
+
+        if (hum_rgb_color := state.get(DreoDirective.HUMIDIFIER_RGB_COLOR)) is not None:
+            humidifier_data.rgb_color = int(hum_rgb_color)
+
         if (
             rgb_brightness := state.get(DreoDirective.AMBIENT_RGB_BRIGHTNESS)
         ) is not None:

--- a/custom_components/dreo/coordinator.py
+++ b/custom_components/dreo/coordinator.py
@@ -914,13 +914,11 @@ class DreoHumidifierDeviceData(DreoGenericDeviceData):
         if (hum_rgb_mode := state.get(DreoDirective.HUMIDIFIER_RGB_MODE)) is not None:
             humidifier_data.rgb_mode = str(hum_rgb_mode)
 
+        # HHM005S has no separate on/off directive for the RGB night-light:
+        # `rgb_color=0` is the physical off state, so derive rgb_state from that.
         if (hum_rgb_color := state.get(DreoDirective.HUMIDIFIER_RGB_COLOR)) is not None:
             humidifier_data.rgb_color = int(hum_rgb_color)
-
-        # ledlevel ("On"/"Off") is the authoritative on/off switch on HHM005S.
-        # rgbmode ("Custom"/...) describes the animation mode but doesn't accept "Off".
-        if (led_level := state.get(DreoDirective.HUMIDIFIER_LED_LEVEL)) is not None:
-            humidifier_data.rgb_state = str(led_level) == "On"
+            humidifier_data.rgb_state = int(hum_rgb_color) != 0
 
         if (
             rgb_brightness := state.get(DreoDirective.AMBIENT_RGB_BRIGHTNESS)

--- a/custom_components/dreo/light.py
+++ b/custom_components/dreo/light.py
@@ -209,7 +209,7 @@ class DreoRGBLight(DreoEntity, LightEntity):
         """Turn on the RGB light."""
         if self._uses_humidifier_rgb_dialect:
             command_params: dict[str, Any] = {
-                DreoDirective.HUMIDIFIER_RGB_MODE: "Custom"
+                DreoDirective.HUMIDIFIER_LED_LEVEL: "On"
             }
             if ATTR_RGB_COLOR in kwargs:
                 r, g, b = kwargs[ATTR_RGB_COLOR]
@@ -286,7 +286,7 @@ class DreoRGBLight(DreoEntity, LightEntity):
         if self._uses_humidifier_rgb_dialect:
             await self.async_send_command_and_update(
                 DreoErrorCode.TURN_OFF_FAILED,
-                **{DreoDirective.HUMIDIFIER_RGB_MODE: "Off"},
+                **{DreoDirective.HUMIDIFIER_LED_LEVEL: "Off"},
             )
             return
         await self.async_send_command_and_update(

--- a/custom_components/dreo/light.py
+++ b/custom_components/dreo/light.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     from . import DreoConfigEntry
 from .const import (
     DOMAIN,
+    HUMIDIFIER_RGB_COLOR_MODELS,
     DreoDeviceType,
     DreoDirective,
     DreoEntityConfigSpec,
@@ -86,12 +87,18 @@ async def async_setup_entry(
             if not device_id:
                 continue
 
-            if Platform.LIGHT not in device.get(
+            model = device.get("model")
+            entity_supports = device.get(
                 DreoEntityConfigSpec.TOP_CONFIG, {}
-            ).get("entitySupports", []):
-                _LOGGER.warning(
-                    "No light entity support for model %s", device.get("model")
-                )
+            ).get("entitySupports", [])
+            # DR-HHM005S and friends don't declare "light" in entitySupports even
+            # though they have an RGB night light. Force the entity for those models.
+            force_humidifier_rgb = (
+                device_type == DreoDeviceType.HUMIDIFIER
+                and model in HUMIDIFIER_RGB_COLOR_MODELS
+            )
+            if Platform.LIGHT not in entity_supports and not force_humidifier_rgb:
+                _LOGGER.warning("No light entity support for model %s", model)
                 continue
 
             coordinator = config_entry.runtime_data.coordinators.get(device_id)
@@ -106,7 +113,7 @@ async def async_setup_entry(
             elif device_type == DreoDeviceType.RGBLIGHT_CEILING_FAN:
                 lights.append(DreoRGBLight(device, coordinator))
                 lights.append(DreoRegularLight(device, coordinator))
-            elif device_type == DreoDeviceType.HEC or DreoDeviceType.HUMIDIFIER:
+            elif device_type in (DreoDeviceType.HEC, DreoDeviceType.HUMIDIFIER):
                 lights.append(DreoRGBLight(device, coordinator))
         if lights:
             async_add_entities(lights)
@@ -135,10 +142,16 @@ class DreoRGBLight(DreoEntity, LightEntity):
         device_id = device.get("deviceSn")
         self._attr_unique_id = f"{device_id}_rgb_light"
         self._device_type = coordinator.device_type
+        # Models in this set use the humidifier-native `rgbmode` + `rgb_color` dialect
+        # (no brightness, no effects). All other RGB devices keep the atm* dialect.
+        self._uses_humidifier_rgb_dialect = (
+            self._device_type == DreoDeviceType.HUMIDIFIER
+            and device.get("model") in HUMIDIFIER_RGB_COLOR_MODELS
+        )
 
         rgb_light_config = coordinator.model_config.get(
             DreoEntityConfigSpec.RGBLIGHT_ENTITY_CONF, {}
-        )
+        ) or {}
 
         self._attr_effect_list = rgb_light_config.get(DreoFeatureSpec.LIGHT_MODES)
         self._brightness_percentage = tuple(
@@ -194,6 +207,20 @@ class DreoRGBLight(DreoEntity, LightEntity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the RGB light."""
+        if self._uses_humidifier_rgb_dialect:
+            command_params: dict[str, Any] = {
+                DreoDirective.HUMIDIFIER_RGB_MODE: "Custom"
+            }
+            if ATTR_RGB_COLOR in kwargs:
+                r, g, b = kwargs[ATTR_RGB_COLOR]
+                command_params[DreoDirective.HUMIDIFIER_RGB_COLOR] = (
+                    (r << 16) | (g << 8) | b
+                )
+            await self.async_send_command_and_update(
+                DreoErrorCode.TURN_ON_FAILED, **command_params
+            )
+            return
+
         command_params: dict[str, Any] = {DreoDirective.AMBIENT_SWITCH: True}
 
         if ATTR_RGB_COLOR in kwargs:
@@ -256,6 +283,12 @@ class DreoRGBLight(DreoEntity, LightEntity):
 
     async def async_turn_off(self, **_: Any) -> None:
         """Turn off the RGB light."""
+        if self._uses_humidifier_rgb_dialect:
+            await self.async_send_command_and_update(
+                DreoErrorCode.TURN_OFF_FAILED,
+                **{DreoDirective.HUMIDIFIER_RGB_MODE: "Off"},
+            )
+            return
         await self.async_send_command_and_update(
             DreoErrorCode.TURN_OFF_FAILED, ambient_switch=False
         )
@@ -263,6 +296,8 @@ class DreoRGBLight(DreoEntity, LightEntity):
     @property
     def supported_features(self) -> LightEntityFeature:
         """Return the supported features based on current mode."""
+        if self._uses_humidifier_rgb_dialect:
+            return LightEntityFeature(0)
         return LightEntityFeature.TRANSITION | LightEntityFeature.EFFECT
 
     @property
@@ -289,7 +324,12 @@ class DreoRGBLight(DreoEntity, LightEntity):
             return
 
         color_int = (red << 16) | (green << 8) | blue
-        command_params: dict[str, Any] = {DreoDirective.AMBIENT_RGB_COLOR: color_int}
+        color_key = (
+            DreoDirective.HUMIDIFIER_RGB_COLOR
+            if self._uses_humidifier_rgb_dialect
+            else DreoDirective.AMBIENT_RGB_COLOR
+        )
+        command_params: dict[str, Any] = {color_key: color_int}
 
         await self.async_send_command_and_update(
             DreoErrorCode.TURN_ON_FAILED, **command_params

--- a/custom_components/dreo/light.py
+++ b/custom_components/dreo/light.py
@@ -148,6 +148,9 @@ class DreoRGBLight(DreoEntity, LightEntity):
             self._device_type == DreoDeviceType.HUMIDIFIER
             and device.get("model") in HUMIDIFIER_RGB_COLOR_MODELS
         )
+        # HHM005S has no on/off directive for the RGB night-light; we treat
+        # `rgb_color=0` as off and restore this color on turn_on.
+        self._last_nonzero_rgb_color: int | None = None
 
         rgb_light_config = coordinator.model_config.get(
             DreoEntityConfigSpec.RGBLIGHT_ENTITY_CONF, {}
@@ -208,16 +211,18 @@ class DreoRGBLight(DreoEntity, LightEntity):
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn on the RGB light."""
         if self._uses_humidifier_rgb_dialect:
-            command_params: dict[str, Any] = {
-                DreoDirective.HUMIDIFIER_LED_LEVEL: "On"
-            }
+            # HHM005S has no on/off directive for the RGB night-light —
+            # `rgb_color=0` is the physical "off". So "on" means restoring
+            # a non-zero color: either the one the caller sent, or the last
+            # non-zero color we observed (cached on toggle-off), or white.
             if ATTR_RGB_COLOR in kwargs:
                 r, g, b = kwargs[ATTR_RGB_COLOR]
-                command_params[DreoDirective.HUMIDIFIER_RGB_COLOR] = (
-                    (r << 16) | (g << 8) | b
-                )
+                color_int = (r << 16) | (g << 8) | b
+            else:
+                color_int = self._last_nonzero_rgb_color or 0xFFFFFF
             await self.async_send_command_and_update(
-                DreoErrorCode.TURN_ON_FAILED, **command_params
+                DreoErrorCode.TURN_ON_FAILED,
+                **{DreoDirective.HUMIDIFIER_RGB_COLOR: color_int},
             )
             return
 
@@ -284,9 +289,13 @@ class DreoRGBLight(DreoEntity, LightEntity):
     async def async_turn_off(self, **_: Any) -> None:
         """Turn off the RGB light."""
         if self._uses_humidifier_rgb_dialect:
+            # Cache the currently-displayed color so turn_on can restore it.
+            current = self.coordinator.data
+            if current and _has_rgb_features(current) and current.rgb_color:
+                self._last_nonzero_rgb_color = int(current.rgb_color)
             await self.async_send_command_and_update(
                 DreoErrorCode.TURN_OFF_FAILED,
-                **{DreoDirective.HUMIDIFIER_LED_LEVEL: "Off"},
+                **{DreoDirective.HUMIDIFIER_RGB_COLOR: 0},
             )
             return
         await self.async_send_command_and_update(

--- a/custom_components/dreo/manifest.json
+++ b/custom_components/dreo/manifest.json
@@ -4,11 +4,11 @@
   "codeowners": ["@w-xtao"],
   "config_flow": true,
   "dependencies": ["logger"],
-  "documentation": "https://github.com/dreo-team/hass-dreoverse/blob/master/README.md",
+  "documentation": "https://github.com/constantinchik/hass-dreoverse/blob/master/README.md",
   "integration_type": "hub",
   "iot_class": "cloud_polling",
-  "issue_tracker": "https://github.com/dreo-team/hass-dreoverse/issues",
+  "issue_tracker": "https://github.com/constantinchik/hass-dreoverse/issues",
   "quality_scale": "bronze",
   "requirements": ["pydreo-cloud==1.0.0"],
-  "version": "2.2.1"
+  "version": "2.2.2"
 }

--- a/custom_components/dreo/manifest.json
+++ b/custom_components/dreo/manifest.json
@@ -4,11 +4,11 @@
   "codeowners": ["@w-xtao"],
   "config_flow": true,
   "dependencies": ["logger"],
-  "documentation": "https://github.com/constantinchik/hass-dreoverse/blob/master/README.md",
+  "documentation": "https://github.com/dreo-team/hass-dreoverse/blob/master/README.md",
   "integration_type": "hub",
   "iot_class": "cloud_polling",
-  "issue_tracker": "https://github.com/constantinchik/hass-dreoverse/issues",
+  "issue_tracker": "https://github.com/dreo-team/hass-dreoverse/issues",
   "quality_scale": "bronze",
   "requirements": ["pydreo-cloud==1.0.0"],
-  "version": "2.2.2"
+  "version": "2.2.1"
 }

--- a/custom_components/dreo/switch.py
+++ b/custom_components/dreo/switch.py
@@ -14,8 +14,16 @@ if TYPE_CHECKING:
 
     from . import DreoConfigEntry
     from .coordinator import DreoDataUpdateCoordinator
-from .const import DreoEntityConfigSpec, DreoErrorCode
+from .const import HUMIDIFIER_RGB_COLOR_MODELS, DreoEntityConfigSpec, DreoErrorCode
 from .entity import DreoEntity
+
+# Toggle fields whose state is never reported by the device, so their switch
+# entities would auto-revert in the UI. We suppress them per-model when a
+# better entity (e.g. the RGB light) already covers the capability.
+_SUPPRESSED_TOGGLE_FIELDS_BY_MODEL: dict[str, frozenset[str]] = {
+    model: frozenset({"ambient_Light_switch", "ambient_light_switch"})
+    for model in HUMIDIFIER_RGB_COLOR_MODELS
+}
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -61,12 +69,22 @@ async def async_setup_entry(
                 "mute_switch": DreoErrorCode.SET_MUTE_SWITCH_FAILED,
             }
 
+            suppressed = _SUPPRESSED_TOGGLE_FIELDS_BY_MODEL.get(
+                device.get("model"), frozenset()
+            )
             for toggle_switch in toggle_switches.values():
                 field = toggle_switch.get("field")
 
                 if not field:
                     _LOGGER.warning(
                         "Skipping toggle switch with missing field in model %s",
+                        device.get("model"),
+                    )
+                    continue
+                if field in suppressed:
+                    _LOGGER.debug(
+                        "Suppressing toggle %s on model %s (covered by another entity)",
+                        field,
                         device.get("model"),
                     )
                     continue

--- a/custom_components/dreo/switch.py
+++ b/custom_components/dreo/switch.py
@@ -14,8 +14,19 @@ if TYPE_CHECKING:
 
     from . import DreoConfigEntry
     from .coordinator import DreoDataUpdateCoordinator
-from .const import HUMIDIFIER_RGB_COLOR_MODELS, DreoEntityConfigSpec, DreoErrorCode
+from .const import (
+    HUMIDIFIER_RGB_COLOR_MODELS,
+    DreoDeviceType,
+    DreoDirective,
+    DreoEntityConfigSpec,
+    DreoErrorCode,
+    DreoFeatureSpec,
+)
+from .coordinator import DreoHumidifierDeviceData
 from .entity import DreoEntity
+
+SLEEP_MODE = "Sleep"
+DEFAULT_NON_SLEEP_MODE = "Manual"
 
 # Toggle fields whose state is never reported by the device, so their switch
 # entities would auto-revert in the UI. We suppress them per-model when a
@@ -37,7 +48,7 @@ async def async_setup_entry(
 
     @callback
     def async_add_switch_entities() -> None:
-        entities: list[DreoToggleSwitch] = []
+        entities: list[SwitchEntity] = []
 
         for device in config_entry.runtime_data.devices:
             device_id = device.get("deviceSn")
@@ -45,14 +56,20 @@ async def async_setup_entry(
                 continue
 
             device_config = device.get(DreoEntityConfigSpec.TOP_CONFIG, {})
+            coordinator = config_entry.runtime_data.coordinators.get(device_id)
+            if not coordinator:
+                continue
+
+            if (
+                device.get("deviceType") == DreoDeviceType.HUMIDIFIER
+                and _supports_sleep_mode(device_config)
+            ):
+                entities.append(DreoHumidifierSleepModeSwitch(device, coordinator))
+
             if Platform.SWITCH not in device_config.get("entitySupports", []):
                 _LOGGER.warning(
                     "No switch entity support for model %s", device.get("model")
                 )
-                continue
-
-            coordinator = config_entry.runtime_data.coordinators.get(device_id)
-            if not coordinator:
                 continue
 
             toggle_switches = device_config.get(
@@ -211,3 +228,58 @@ class DreoToggleSwitch(DreoEntity, SwitchEntity):
         if self._field == "fanOnTempMet_switch":
             return "mdi:weather-windy" if is_on else "mdi:air-filter"
         return None
+
+
+def _supports_sleep_mode(device_config: dict[str, Any]) -> bool:
+    """Return True if the humidifier advertises Sleep as a preset mode."""
+    humidifier_config = device_config.get(
+        DreoEntityConfigSpec.HUMIDIFIER_ENTITY_CONF, {}
+    )
+    mode_config = humidifier_config.get(DreoFeatureSpec.HUMIDIFIER_MODE_CONFIG, {})
+    return SLEEP_MODE in (mode_config.get(DreoFeatureSpec.PRESET_MODES) or [])
+
+
+class DreoHumidifierSleepModeSwitch(DreoEntity, SwitchEntity):
+    """Switch that toggles Sleep mode on a Dreo humidifier.
+
+    Exists because HomeKit's humidifier accessory only exposes humidify/off,
+    so Sleep mode isn't reachable from Apple Home without a separate switch.
+    """
+
+    _attr_icon = "mdi:weather-night"
+
+    def __init__(
+        self,
+        device: dict[str, Any],
+        coordinator: DreoDataUpdateCoordinator,
+    ) -> None:
+        """Initialize the Sleep-mode switch."""
+        super().__init__(device, coordinator, "sleep_mode", "Sleep Mode")
+        self._last_non_sleep_mode: str = DEFAULT_NON_SLEEP_MODE
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Refresh is_on from coordinator mode; remember last non-Sleep mode."""
+        data = self.coordinator.data
+        if isinstance(data, DreoHumidifierDeviceData) and data.mode:
+            self._attr_is_on = data.mode == SLEEP_MODE
+            if data.mode != SLEEP_MODE:
+                self._last_non_sleep_mode = data.mode
+        super()._handle_coordinator_update()
+
+    async def async_turn_on(self, **_: Any) -> None:
+        """Switch the humidifier into Sleep mode (powering it on if needed)."""
+        params: dict[str, Any] = {DreoDirective.MODE: SLEEP_MODE}
+        data = self.coordinator.data
+        if not (isinstance(data, DreoHumidifierDeviceData) and data.is_on):
+            params[DreoDirective.POWER_SWITCH] = True
+        await self.async_send_command_and_update(
+            DreoErrorCode.SET_HUMIDIFIER_MODE_FAILED, **params
+        )
+
+    async def async_turn_off(self, **_: Any) -> None:
+        """Leave Sleep mode by restoring the previous mode (default Manual)."""
+        await self.async_send_command_and_update(
+            DreoErrorCode.SET_HUMIDIFIER_MODE_FAILED,
+            **{DreoDirective.MODE: self._last_non_sleep_mode},
+        )


### PR DESCRIPTION
## Summary

This PR adds full support for the Dreo HM735S smart humidifier (`DR-HHM005S`).

It includes:
- support for the HM735S RGB night-light control path
- proper handling of the humidifier-specific `rgbmode` / `rgb_color` directive dialect
- correct RGB off-state handling for devices where `rgb_color=0` represents physical off
- a dedicated Sleep mode switch entity
- README updates to list `DR-HHM005S` as a supported humidifier

## Why this is needed

`DR-HHM005S` does not behave like the existing ambient-light fan/HEC devices. Its light state is exposed through humidifier-specific directives, and it does not expose a normal separate light on/off directive. This PR adds the model-specific handling required for the device to work correctly in Home Assistant.

## Testing

I’ve been testing this with my own HM735S (`DR-HHM005S`) device, and it works like a charm.

Verified on my device:
- humidifier control
- RGB night-light control
- RGB on/off behavior
- Sleep mode switch behavior

## Notes

This PR keeps the existing behavior for other Dreo devices intact while adding the model-specific handling needed for `DR-HHM005S`.
