### PR TITLE
Add configurable cloud polling interval

### DIFF
--- a/custom_components/dreo/__init__.py
+++ b/custom_components/dreo/__init__.py
@@ -7,12 +7,17 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
+from homeassistant.const import (
+    CONF_PASSWORD,
+    CONF_SCAN_INTERVAL,
+    CONF_USERNAME,
+    Platform,
+)
 from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from pydreo.client import DreoClient
 from pydreo.exceptions import DreoBusinessException, DreoException
 
-from .const import DreoEntityConfigSpec
+from .const import DEFAULT_SCAN_INTERVAL, DreoEntityConfigSpec
 from .coordinator import DreoDataUpdateCoordinator
 
 if TYPE_CHECKING:
@@ -73,10 +78,18 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: DreoConfigEntry) 
     client, devices = await async_login(hass, username, password)
     coordinators: dict[str, DreoDataUpdateCoordinator] = {}
 
+    scan_interval = int(
+        config_entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+    )
+
     for device in devices:
-        await async_setup_device_coordinator(hass, client, device, coordinators)
+        await async_setup_device_coordinator(
+            hass, client, device, coordinators, scan_interval
+        )
 
     config_entry.runtime_data = DreoData(client, devices, coordinators)
+
+    config_entry.async_on_unload(config_entry.add_update_listener(async_update_options))
 
     await hass.config_entries.async_forward_entry_setups(config_entry, PLATFORMS)
 
@@ -91,11 +104,19 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: DreoConfigEntry) 
     return True
 
 
+async def async_update_options(
+    hass: HomeAssistant, config_entry: DreoConfigEntry
+) -> None:
+    """Reload the entry when options change so the new scan interval applies."""
+    await hass.config_entries.async_reload(config_entry.entry_id)
+
+
 async def async_setup_device_coordinator(
     hass: HomeAssistant,
     client: DreoClient,
     device: dict[str, Any],
     coordinators: dict[str, DreoDataUpdateCoordinator],
+    scan_interval: int = DEFAULT_SCAN_INTERVAL,
 ) -> None:
     """Set up coordinator for a single device."""
     device_model = device.get("model")
@@ -115,7 +136,7 @@ async def async_setup_device_coordinator(
         return
 
     coordinator = DreoDataUpdateCoordinator(
-        hass, client, device_id, device_type, model_config
+        hass, client, device_id, device_type, model_config, scan_interval
     )
 
     if coordinator.data_processor is None:

--- a/custom_components/dreo/config_flow.py
+++ b/custom_components/dreo/config_flow.py
@@ -1,15 +1,29 @@
 """Config flow to configure Dreo."""
 
+from __future__ import annotations
+
 import hashlib
 from typing import Any
 
 import voluptuous as vol
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.config_entries import (
+    ConfigEntry,
+    ConfigFlow,
+    ConfigFlowResult,
+    OptionsFlow,
+)
+from homeassistant.const import CONF_PASSWORD, CONF_SCAN_INTERVAL, CONF_USERNAME
+from homeassistant.core import callback
+from homeassistant.helpers import selector
 from pydreo.client import DreoClient
 from pydreo.exceptions import DreoBusinessException, DreoException
 
-from .const import DOMAIN
+from .const import (
+    DEFAULT_SCAN_INTERVAL,
+    DOMAIN,
+    MAX_SCAN_INTERVAL,
+    MIN_SCAN_INTERVAL,
+)
 
 DATA_SCHEMA = vol.Schema(
     {vol.Required(CONF_USERNAME): str, vol.Required(CONF_PASSWORD): str}
@@ -20,6 +34,14 @@ class DreoFlowHandler(ConfigFlow, domain=DOMAIN):
     """Handle a Dreo config flow."""
 
     VERSION = 1
+
+    @staticmethod
+    @callback
+    def async_get_options_flow(
+        config_entry: ConfigEntry,  # noqa: ARG004
+    ) -> DreoOptionsFlowHandler:
+        """Get the options flow for this handler."""
+        return DreoOptionsFlowHandler()
 
     @staticmethod
     def _hash_password(password: str) -> str:
@@ -62,3 +84,35 @@ class DreoFlowHandler(ConfigFlow, domain=DOMAIN):
         return self.async_show_form(
             step_id="user", data_schema=DATA_SCHEMA, errors=errors
         )
+
+
+class DreoOptionsFlowHandler(OptionsFlow):
+    """Handle Dreo integration options."""
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Manage the Dreo options."""
+        if user_input is not None:
+            return self.async_create_entry(data=user_input)
+
+        current_interval = self.config_entry.options.get(
+            CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL
+        )
+        options_schema = vol.Schema(
+            {
+                vol.Required(
+                    CONF_SCAN_INTERVAL,
+                    default=current_interval,
+                ): selector.NumberSelector(
+                    selector.NumberSelectorConfig(
+                        min=MIN_SCAN_INTERVAL,
+                        max=MAX_SCAN_INTERVAL,
+                        step=5,
+                        unit_of_measurement="seconds",
+                        mode=selector.NumberSelectorMode.BOX,
+                    )
+                ),
+            }
+        )
+        return self.async_show_form(step_id="init", data_schema=options_schema)

--- a/custom_components/dreo/const.py
+++ b/custom_components/dreo/const.py
@@ -4,6 +4,12 @@ from enum import StrEnum
 
 DOMAIN = "dreo"
 
+# Cloud polling interval (seconds). The Dreo cloud API is rate limited, so the
+# default is intentionally conservative; it can be tuned via the options flow.
+DEFAULT_SCAN_INTERVAL = 60
+MIN_SCAN_INTERVAL = 15
+MAX_SCAN_INTERVAL = 3600
+
 
 class DreoEntityConfigSpec(StrEnum):
     """Dreo config keys."""

--- a/custom_components/dreo/coordinator.py
+++ b/custom_components/dreo/coordinator.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from homeassistant.core import HomeAssistant
     from pydreo.client import DreoClient
 from .const import (
+    DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     DreoDeviceType,
     DreoDirective,
@@ -26,7 +27,6 @@ from .const import (
 
 _LOGGER = logging.getLogger(__name__)
 
-UPDATE_INTERVAL = timedelta(seconds=15)
 MIN_RANGE_LEN = 2
 
 
@@ -1048,20 +1048,21 @@ DreoDeviceData = (
 class DreoDataUpdateCoordinator(DataUpdateCoordinator[DreoDeviceData | None]):
     """Class to manage fetching Dreo data."""
 
-    def __init__(
+    def __init__(  # noqa: PLR0913
         self,
         hass: HomeAssistant,
         client: DreoClient,
         device_id: str,
         device_type: str,
         model_config: dict[str, Any],
+        scan_interval: int = DEFAULT_SCAN_INTERVAL,
     ) -> None:
         """Initialize the coordinator."""
         super().__init__(
             hass,
             _LOGGER,
             name=DOMAIN,
-            update_interval=UPDATE_INTERVAL,
+            update_interval=timedelta(seconds=scan_interval),
         )
         self.client = client
         self.device_id = device_id

--- a/custom_components/dreo/strings.json
+++ b/custom_components/dreo/strings.json
@@ -19,6 +19,17 @@
       }
     }
   },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Dreo options",
+        "description": "How often Home Assistant polls the Dreo cloud for device state. Higher values make fewer API calls; changes made from the Dreo app or device may take up to this long to appear.",
+        "data": {
+          "scan_interval": "Polling interval (seconds)"
+        }
+      }
+    }
+  },
   "exceptions": {
     "humidity_not_supported_in_mode": {
       "message": "Humidity control is not supported in the current mode"

--- a/custom_components/dreo/translations/en.json
+++ b/custom_components/dreo/translations/en.json
@@ -19,6 +19,17 @@
             }
         }
     },
+    "options": {
+        "step": {
+            "init": {
+                "title": "Dreo options",
+                "description": "How often Home Assistant polls the Dreo cloud for device state. Higher values make fewer API calls; changes made from the Dreo app or device may take up to this long to appear.",
+                "data": {
+                    "scan_interval": "Polling interval (seconds)"
+                }
+            }
+        }
+    },
     "exceptions": {
         "humidity_not_supported_in_mode": {
             "message": "Humidity control is not supported in the current mode"


### PR DESCRIPTION
## Summary

The data update coordinator polls the Dreo cloud on a hardcoded 15-second
interval (`UPDATE_INTERVAL = timedelta(seconds=15)` in `coordinator.py`). For a
`cloud_polling` integration that is quite aggressive — each device makes
~5,760 requests/day — and raises the chance of hitting the cloud API rate
limit (`HTTP 429` → `DreoFlowControlException`).

This PR makes the polling interval user-configurable via an **options flow**.

## Changes

- **`const.py`** — add `DEFAULT_SCAN_INTERVAL` (60), `MIN_SCAN_INTERVAL` (15),
  `MAX_SCAN_INTERVAL` (3600).
- **`coordinator.py`** — `DreoDataUpdateCoordinator` takes a `scan_interval`
  argument instead of the module-level `UPDATE_INTERVAL` constant.
- **`config_flow.py`** — add `DreoOptionsFlowHandler` (a `scan_interval`
  `NumberSelector`, 15–3600s) and register it via `async_get_options_flow`.
- **`__init__.py`** — read `scan_interval` from `config_entry.options`, pass it
  to each coordinator, and add an update listener that reloads the entry when
  the option changes so the new interval applies without a restart.
- **`strings.json` / `translations/en.json`** — strings for the new options step.

## Default behaviour

The default is **60s** rather than the previous 15s, cutting per-device traffic
by ~75% out of the box. HA-initiated commands already refresh immediately via
`async_send_command_and_update`, so the interval only governs how quickly
externally-made changes (physical controls / the Dreo app) are reflected. If
maintainers prefer to preserve the historical 15s default, I'm happy to change
`DEFAULT_SCAN_INTERVAL` back to 15 — the option still lets users reduce it.

## Testing

- `scripts/lint` (ruff 0.6.1 `check` + `format --check`) passes clean.
- Verified the modules import and the options flow renders; changing the
  interval reloads the entry and the coordinator picks up the new
  `update_interval`.
